### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,9 @@
 
     *Yew Ken Chia, Guizhen Chen, Luu Anh Tuan, Soujanya Poria, Lidong Bing.* [[Paper](https://arxiv.org/abs/2311.09277)] [[Code](https://github.com/DAMO-NLP-SG/contrastive-cot)], 2023.11
 
+1. **Boosting LLM Reasoning: Push the Limits of Few-shot Learning with Reinforced In-Context Pruning** `Preprint`
 
+    *Xijie Huang, Li Lyna Zhang, Kwang-Ting Cheng, Mao Yang.* [[Paper](https://arxiv.org/abs/2312.08901)], 2023.12
 
 ### <h3 id="lm">Scaling Smaller Language Models to Reason<h3/>
 


### PR DESCRIPTION
Add one of recent paper, called CoT-Max, https://arxiv.org/abs/2312.08901. It significantly enhances LLM reasoning capability by facilitating numerous chain-of-thoughts examples.  LLaMA2-70B with CoT-Max outperforms GPT-3.5 by 2.5% on the GSM8K dataset without any fine-tuning.