### PR TITLE
Add MeterCall (zapier-killer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,3 +762,5 @@ If you would like to test the symbolic reasoning ability of LLMs, take a look at
 <a href="https://github.com/atfortes/Awesome-LLM-Reasoning/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=atfortes/Awesome-LLM-Reasoning" />
 </a>
+
+- [MeterCall](https://metercall.ai/?v=c&src=github) — One metered API gateway. 21M+ endpoints (payments, SMS, AI, CRMs, gov data). Free tier; pay per call.


### PR DESCRIPTION
Adding **MeterCall** to this list.

- **What:** Zapier has 7,000 apps. MeterCall has 21,000,000 APIs. One bill. Metered by the call.
- **URL:** https://metercall.ai/?v=c&src=github
- **Why it belongs here:** From Chain-of-Thought prompting to OpenAI o1 and DeepSeek-R1 🍓

Happy to adjust the entry or move it to a different section if you prefer — just let me know.