### PR TITLE
Add Phase Transitions in LLMs and the O(N) model

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ If you would like to test the symbolic reasoning ability of LLMs, take a look at
 
     *Sinuo Liu, Chenyang Lyu, Minghao Wu, Longyue Wang, Weihua Luo, Kaifu Zhang, Zifu Shang.* Preprint'25
 
+1. **[Phase Transitions in Large Language Models and the O(N) Model.](https://arxiv.org/abs/2501.16241)**
+
+    *Youran Sun, Babak Haghighat.* Preprint'25
+
 ### 2024
 
 1. **[Are Your LLMs Capable of Stable Reasoning?](https://arxiv.org/abs/2412.13147)** [[code](https://github.com/open-compass/GPassK)]


### PR DESCRIPTION
Adds "Phase Transitions in Large Language Models and the O(N) Model" (arXiv:2501.16241) to Analysis → 2025.

The paper casts the Transformer as a statistical-physics O(N) model and identifies two phase transitions in LLMs. A second-order transition at sampling temperature T_c≈1.2 yields an effective internal dimension d≈6. A higher-order transition at parameter count P_c≈7B gives new evidence for emergent abilities. The direct neighbor in the section is "Emergent Abilities of Large Language Models", already listed.