### PR TITLE
Add PUMA (Preprint'26) + create 2026 section under Reasoning in LLMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,12 @@ If you would like to test the symbolic reasoning ability of LLMs, take a look at
 
 <h3 id="llm">🔤 Reasoning in Large Language Models - <i>An Emergent Ability</i></h3>
 
+### 2026
+
+1. **[Stop When Reasoning Converges: Semantic-Preserving Early Exit for Reasoning Models.](https://arxiv.org/abs/2605.17672)** [[code](https://github.com/giovanni-vaccarino/PUMA)]
+
+    *Dehai Min, Giovanni Vaccarino, Huiyi Chen, Yongliang Wu, Gal Yona, Lu Cheng.* Preprint'26
+
 ### 2025
 
 1. **[JudgeLRM: Large Reasoning Models as a Judge.](https://arxiv.org/abs/2504.00050)**


### PR DESCRIPTION
Two small changes to **🔤 Reasoning in Large Language Models**:

1. **Create new \`### 2026\` year section** at the top (above the existing \`### 2025\`), matching the year-ordered structure used throughout the repo.
2. **Add PUMA** as the inaugural 2026 entry, following the existing format (`**[Title.](url)** [[code](url)]` then `*Authors.* Venue'YY`).

**PUMA** (Stop When Reasoning Converges: Semantic-Preserving Early Exit for Reasoning Models) is a plug-and-play inference-time early-exit framework for Large Reasoning Models that uses **reasoning-level semantic redundancy** as a complementary stopping signal to answer-level confidence/consistency. Architecture: lightweight Redundancy Detector (fine-tuned Qwen3-Embedding-0.6B) + Answer Verification window + Loop Breaker fallback.

Results across 5 LRMs (DeepSeek-R1-Distill-Qwen-7B/14B/32B, Llama-3.1-Nemotron-Nano-8B, Qwen3-30B-A3B-Thinking) and 5 reasoning benchmarks (MATH-500, AIME24, AIME25, OlympiadBench, GPQA-Diamond): **26.2% average token reduction** with preserved (slightly improved) accuracy; 1.40× / 1.28× wall-clock speedup on DS-7B/14B. Also generalizes to LiveCodeBench (code) and zero-shot VLM reasoning (MathVista, MathVision).

- Paper: https://arxiv.org/abs/2605.17672
- Code:  https://github.com/giovanni-vaccarino/PUMA

Thanks!